### PR TITLE
ARC-25 Support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "license": "LGPL-3.0",
       "dependencies": {
         "@json-rpc-tools/utils": "^1.7.6",
-        "@walletconnect/client": "^1.7.4",
-        "algorand-walletconnect-qrcode-modal": "^1.7.4",
-        "algosdk": "^1.13.1",
+        "@walletconnect/client": "^1.7.8",
+        "algorand-walletconnect-qrcode-modal": "^1.7.8-beta.1",
+        "algosdk": "^1.17.0",
         "blockies-ts": "^1.0.0",
         "prop-types": "^15.7.2",
         "qr-image": "^3.2.0",
@@ -2066,54 +2066,54 @@
       }
     },
     "node_modules/@walletconnect/browser-utils": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@walletconnect/browser-utils/-/browser-utils-1.7.4.tgz",
-      "integrity": "sha512-YAM+PyRdJb6WZMUDHPAjlYAad6NrgQypmKiC9iKZhcgcYuFIkbY+tRx+Lp7WAXeZS8TsORagi+Sl4T+MnsRzxA==",
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@walletconnect/browser-utils/-/browser-utils-1.7.8.tgz",
+      "integrity": "sha512-iCL0XCWOZaABIc0lqA79Vyaybr3z26nt8mxiwvfrG8oaKUf5Y21Of4dj+wIXQ4Hhblre6SgDlU0Ffb39+1THOw==",
       "dependencies": {
         "@walletconnect/safe-json": "1.0.0",
-        "@walletconnect/types": "^1.7.4",
+        "@walletconnect/types": "^1.7.8",
         "@walletconnect/window-getters": "1.0.0",
         "@walletconnect/window-metadata": "1.0.0",
         "detect-browser": "5.2.0"
       }
     },
     "node_modules/@walletconnect/client": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@walletconnect/client/-/client-1.7.4.tgz",
-      "integrity": "sha512-J6o5vCv84I1ROI7XGHzkabp37TUXpdyqDRQrg6d0usYQVD7B232Hz9jV4K4Ei9PF5CdauXgafFF95Qanlx1shw==",
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@walletconnect/client/-/client-1.7.8.tgz",
+      "integrity": "sha512-pBroM6jZAaUM0SoXJZg5U7aPTiU3ljQAw3Xh/i2pxFDeN/oPKao7husZ5rdxS5xuGSV6YpqqRb0RxW1IeoR2Pg==",
       "dependencies": {
-        "@walletconnect/core": "^1.7.4",
-        "@walletconnect/iso-crypto": "^1.7.4",
-        "@walletconnect/types": "^1.7.4",
-        "@walletconnect/utils": "^1.7.4"
+        "@walletconnect/core": "^1.7.8",
+        "@walletconnect/iso-crypto": "^1.7.8",
+        "@walletconnect/types": "^1.7.8",
+        "@walletconnect/utils": "^1.7.8"
       }
     },
     "node_modules/@walletconnect/core": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-1.7.4.tgz",
-      "integrity": "sha512-yhNgyc2r5z4r633J4jMfbcC5PzMq7qlie70rXIOqN2apKnnxffqWEogv9DaZvwV/Lr3h/8aEuGIXP1ModriWPg==",
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-1.7.8.tgz",
+      "integrity": "sha512-9xcQ0YNf9JUFb0YOX1Mpy4Yojt+6w2yQz/0aIEyj2X/s9D71NW0fTYsMcdhkLOI7mn2cqVbx2t1lRvdgqsbrSQ==",
       "dependencies": {
-        "@walletconnect/socket-transport": "^1.7.4",
-        "@walletconnect/types": "^1.7.4",
-        "@walletconnect/utils": "^1.7.4"
+        "@walletconnect/socket-transport": "^1.7.8",
+        "@walletconnect/types": "^1.7.8",
+        "@walletconnect/utils": "^1.7.8"
       }
     },
     "node_modules/@walletconnect/crypto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/crypto/-/crypto-1.0.1.tgz",
-      "integrity": "sha512-IgUReNrycIFxkGgq8YT9HsosCkhutakWD9Q411PR0aJfxpEa/VKJeaLRtoz6DvJpztWStwhIHnAbBoOVR72a6g==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/crypto/-/crypto-1.0.2.tgz",
+      "integrity": "sha512-+OlNtwieUqVcOpFTvLBvH+9J9pntEqH5evpINHfVxff1XIgwV55PpbdvkHu6r9Ib4WQDOFiD8OeeXs1vHw7xKQ==",
       "dependencies": {
-        "@walletconnect/encoding": "^1.0.0",
+        "@walletconnect/encoding": "^1.0.1",
         "@walletconnect/environment": "^1.0.0",
-        "@walletconnect/randombytes": "^1.0.1",
+        "@walletconnect/randombytes": "^1.0.2",
         "aes-js": "^3.1.2",
         "hash.js": "^1.1.7"
       }
     },
     "node_modules/@walletconnect/encoding": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/encoding/-/encoding-1.0.0.tgz",
-      "integrity": "sha512-4nkJFnS0QF5JdieG/3VPD1/iEWkLSZ14EBInLZ00RWxmC6EMZrzAeHNAWIgm+xP3NK0lqz+7lEsmWGtcl5gYnQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/encoding/-/encoding-1.0.1.tgz",
+      "integrity": "sha512-8opL2rs6N6E3tJfsqwS82aZQDL3gmupWUgmvuZ3CGU7z/InZs3R9jkzH8wmYtpbq0sFK3WkJkQRZFFk4BkrmFA==",
       "dependencies": {
         "is-typedarray": "1.0.0",
         "typedarray-to-buffer": "3.1.5"
@@ -2125,13 +2125,13 @@
       "integrity": "sha512-4BwqyWy6KpSvkocSaV7WR3BlZfrxLbJSLkg+j7Gl6pTDE+U55lLhJvQaMuDVazXYxcjBsG09k7UlH7cGiUI5vQ=="
     },
     "node_modules/@walletconnect/iso-crypto": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@walletconnect/iso-crypto/-/iso-crypto-1.7.4.tgz",
-      "integrity": "sha512-oqLuBcORDO0doaK7LYissviUVlS//jdrhK8GnMMI6mkNh195FHURoi7jUvSE8Nxr5doUNRi9d7bDrEujA++xtw==",
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@walletconnect/iso-crypto/-/iso-crypto-1.7.8.tgz",
+      "integrity": "sha512-Qo6qDcMG0Ac+9fpWE0h/oE55NHLk6eM2vlXpWlQDN/me7RZGrkvk+LXsAkQ3UiYPEiPfq4eswcyRWC9AcrAscg==",
       "dependencies": {
-        "@walletconnect/crypto": "^1.0.1",
-        "@walletconnect/types": "^1.7.4",
-        "@walletconnect/utils": "^1.7.4"
+        "@walletconnect/crypto": "^1.0.2",
+        "@walletconnect/types": "^1.7.8",
+        "@walletconnect/utils": "^1.7.8"
       }
     },
     "node_modules/@walletconnect/jsonrpc-types": {
@@ -2143,9 +2143,9 @@
       }
     },
     "node_modules/@walletconnect/jsonrpc-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.0.tgz",
-      "integrity": "sha512-qUHbKUK6sHeHn67qtHZoLoYk5hS6x1arTPjKDRkY93/6Fx+ZmNIpdm1owX3l6aYueyegJ7mz43FpvYHUqJ8xcw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.1.tgz",
+      "integrity": "sha512-Ptmcq5SsXlJDE4xuwiqpCGZddPxvneXwDfQL20Ut4TyuZZwR4ZhNFcUBu3FDHBbtDL5qojnmZ1GHqABLJchpBQ==",
       "dependencies": {
         "@walletconnect/environment": "^1.0.0",
         "@walletconnect/jsonrpc-types": "^1.0.0"
@@ -2158,11 +2158,11 @@
       "deprecated": "Deprecated in favor of dynamic registry available from: https://github.com/walletconnect/walletconnect-registry"
     },
     "node_modules/@walletconnect/randombytes": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/randombytes/-/randombytes-1.0.1.tgz",
-      "integrity": "sha512-YJTyq69i0PtxVg7osEpKfvjTaWuAsR49QEcqGKZRKVQWMbGXBZ65fovemK/SRgtiFRv0V8PwsrlKSheqzfPNcg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/randombytes/-/randombytes-1.0.2.tgz",
+      "integrity": "sha512-ivgOtAyqQnN0rLQmOFPemsgYGysd/ooLfaDA/ACQ3cyqlca56t3rZc7pXfqJOIETx/wSyoF5XbwL+BqYodw27A==",
       "dependencies": {
-        "@walletconnect/encoding": "^1.0.0",
+        "@walletconnect/encoding": "^1.0.1",
         "@walletconnect/environment": "^1.0.0",
         "randombytes": "^2.1.0"
       }
@@ -2173,29 +2173,29 @@
       "integrity": "sha512-QJzp/S/86sUAgWY6eh5MKYmSfZaRpIlmCJdi5uG4DJlKkZrHEF7ye7gA+VtbVzvTtpM/gRwO2plQuiooIeXjfg=="
     },
     "node_modules/@walletconnect/socket-transport": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@walletconnect/socket-transport/-/socket-transport-1.7.4.tgz",
-      "integrity": "sha512-5RDIZtyQqs5LFqmluE/5Gy4obaClGVDrhlhZJTUn86R49FppJq2pe362NnoJt6J6xLSLZlZ54WIBl6cIlRoVww==",
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@walletconnect/socket-transport/-/socket-transport-1.7.8.tgz",
+      "integrity": "sha512-bqEjLxfSzG79v2OT7XVOZoyUkg6g3yng0fURrdLusWs42fYHWnrSrIZDejFn8N5PiZk5R2edrggkQ7w0VUUAfw==",
       "dependencies": {
-        "@walletconnect/types": "^1.7.4",
-        "@walletconnect/utils": "^1.7.4",
+        "@walletconnect/types": "^1.7.8",
+        "@walletconnect/utils": "^1.7.8",
         "ws": "7.5.3"
       }
     },
     "node_modules/@walletconnect/types": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-1.7.4.tgz",
-      "integrity": "sha512-jvdW1/7z16dCC3i2uwPSgXjUXkmvJH0M2PbYD8ZETyEj/oSiLd32nPAUZVU0IVqQk4XAZHUTKhlRgxTch1W4Qg=="
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-1.7.8.tgz",
+      "integrity": "sha512-0oSZhKIrtXRJVP1jQ0EDTRtotQY6kggGjDcmm/LLQBKnOZXdPeo0sPkV/7DjT5plT3O7Cjc6JvuXt9WOY0hlCA=="
     },
     "node_modules/@walletconnect/utils": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-1.7.4.tgz",
-      "integrity": "sha512-09667lbpClPpbskCpLllAQ3MSiNnDlTlqcmWANJ/ZuqCqq5ENyytPqkUjPFSfRfRVkgdQ2t/byeQtDd1TEpHcg==",
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-1.7.8.tgz",
+      "integrity": "sha512-DSpfH6Do0TQmdrgzu+SyjVhupVjN0WEMvNWGK9K4VlSmLFpCWfme7qxzrvuxBZ47gDqs1kGWvjyJmviWqvOnAg==",
       "dependencies": {
-        "@walletconnect/browser-utils": "^1.7.4",
-        "@walletconnect/encoding": "^1.0.0",
+        "@walletconnect/browser-utils": "^1.7.8",
+        "@walletconnect/encoding": "^1.0.1",
         "@walletconnect/jsonrpc-utils": "^1.0.0",
-        "@walletconnect/types": "^1.7.4",
+        "@walletconnect/types": "^1.7.8",
         "bn.js": "4.11.8",
         "js-sha3": "0.8.0",
         "query-string": "6.13.5"
@@ -2519,22 +2519,22 @@
       }
     },
     "node_modules/algorand-walletconnect-qrcode-modal": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/algorand-walletconnect-qrcode-modal/-/algorand-walletconnect-qrcode-modal-1.7.4.tgz",
-      "integrity": "sha512-Xj/zt4O6o3f6H8ikXX5yrwVL+/VVwTpFF4N4daHaoK/HEooAGNdkrJ7vftbjhIrs0N8+b8NUqEcMyYdaCS/CKQ==",
+      "version": "1.7.8-beta.1",
+      "resolved": "https://registry.npmjs.org/algorand-walletconnect-qrcode-modal/-/algorand-walletconnect-qrcode-modal-1.7.8-beta.1.tgz",
+      "integrity": "sha512-ayQCMADLTrxe9XCvnuUhMq61KKL7OE1kKA4UO0dwO6qW55ZapQUtWILePSM2zy4Zxw7tZ9yVgsx4D3cXCYgjog==",
       "dependencies": {
-        "@walletconnect/browser-utils": "^1.7.4",
+        "@walletconnect/browser-utils": "^1.7.8",
         "@walletconnect/mobile-registry": "^1.4.0",
-        "@walletconnect/types": "^1.7.4",
+        "@walletconnect/types": "^1.7.8",
         "copy-to-clipboard": "^3.3.1",
         "preact": "10.4.1",
         "qrcode": "1.4.4"
       }
     },
     "node_modules/algosdk": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/algosdk/-/algosdk-1.13.1.tgz",
-      "integrity": "sha512-htyJI1/zVcOzpNZVT8PHn4K0yXXTS+b7RXplc7nmFqGVThbM8+ufbnBLChxVPh3BVxqqpqS13VTsQcNArK10jg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/algosdk/-/algosdk-1.17.0.tgz",
+      "integrity": "sha512-WwHbZV03tZ2C/VLOapWOzJImm4lokav9HXnPLqbGrXyb8Gn/Q2AsoKMbOxd6MTzWguhaXU4Yk0VtbFlYhkaeoA==",
       "dependencies": {
         "algo-msgpack-with-bigint": "^2.1.1",
         "buffer": "^6.0.2",
@@ -24784,54 +24784,54 @@
       }
     },
     "@walletconnect/browser-utils": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@walletconnect/browser-utils/-/browser-utils-1.7.4.tgz",
-      "integrity": "sha512-YAM+PyRdJb6WZMUDHPAjlYAad6NrgQypmKiC9iKZhcgcYuFIkbY+tRx+Lp7WAXeZS8TsORagi+Sl4T+MnsRzxA==",
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@walletconnect/browser-utils/-/browser-utils-1.7.8.tgz",
+      "integrity": "sha512-iCL0XCWOZaABIc0lqA79Vyaybr3z26nt8mxiwvfrG8oaKUf5Y21Of4dj+wIXQ4Hhblre6SgDlU0Ffb39+1THOw==",
       "requires": {
         "@walletconnect/safe-json": "1.0.0",
-        "@walletconnect/types": "^1.7.4",
+        "@walletconnect/types": "^1.7.8",
         "@walletconnect/window-getters": "1.0.0",
         "@walletconnect/window-metadata": "1.0.0",
         "detect-browser": "5.2.0"
       }
     },
     "@walletconnect/client": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@walletconnect/client/-/client-1.7.4.tgz",
-      "integrity": "sha512-J6o5vCv84I1ROI7XGHzkabp37TUXpdyqDRQrg6d0usYQVD7B232Hz9jV4K4Ei9PF5CdauXgafFF95Qanlx1shw==",
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@walletconnect/client/-/client-1.7.8.tgz",
+      "integrity": "sha512-pBroM6jZAaUM0SoXJZg5U7aPTiU3ljQAw3Xh/i2pxFDeN/oPKao7husZ5rdxS5xuGSV6YpqqRb0RxW1IeoR2Pg==",
       "requires": {
-        "@walletconnect/core": "^1.7.4",
-        "@walletconnect/iso-crypto": "^1.7.4",
-        "@walletconnect/types": "^1.7.4",
-        "@walletconnect/utils": "^1.7.4"
+        "@walletconnect/core": "^1.7.8",
+        "@walletconnect/iso-crypto": "^1.7.8",
+        "@walletconnect/types": "^1.7.8",
+        "@walletconnect/utils": "^1.7.8"
       }
     },
     "@walletconnect/core": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-1.7.4.tgz",
-      "integrity": "sha512-yhNgyc2r5z4r633J4jMfbcC5PzMq7qlie70rXIOqN2apKnnxffqWEogv9DaZvwV/Lr3h/8aEuGIXP1ModriWPg==",
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-1.7.8.tgz",
+      "integrity": "sha512-9xcQ0YNf9JUFb0YOX1Mpy4Yojt+6w2yQz/0aIEyj2X/s9D71NW0fTYsMcdhkLOI7mn2cqVbx2t1lRvdgqsbrSQ==",
       "requires": {
-        "@walletconnect/socket-transport": "^1.7.4",
-        "@walletconnect/types": "^1.7.4",
-        "@walletconnect/utils": "^1.7.4"
+        "@walletconnect/socket-transport": "^1.7.8",
+        "@walletconnect/types": "^1.7.8",
+        "@walletconnect/utils": "^1.7.8"
       }
     },
     "@walletconnect/crypto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/crypto/-/crypto-1.0.1.tgz",
-      "integrity": "sha512-IgUReNrycIFxkGgq8YT9HsosCkhutakWD9Q411PR0aJfxpEa/VKJeaLRtoz6DvJpztWStwhIHnAbBoOVR72a6g==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/crypto/-/crypto-1.0.2.tgz",
+      "integrity": "sha512-+OlNtwieUqVcOpFTvLBvH+9J9pntEqH5evpINHfVxff1XIgwV55PpbdvkHu6r9Ib4WQDOFiD8OeeXs1vHw7xKQ==",
       "requires": {
-        "@walletconnect/encoding": "^1.0.0",
+        "@walletconnect/encoding": "^1.0.1",
         "@walletconnect/environment": "^1.0.0",
-        "@walletconnect/randombytes": "^1.0.1",
+        "@walletconnect/randombytes": "^1.0.2",
         "aes-js": "^3.1.2",
         "hash.js": "^1.1.7"
       }
     },
     "@walletconnect/encoding": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/encoding/-/encoding-1.0.0.tgz",
-      "integrity": "sha512-4nkJFnS0QF5JdieG/3VPD1/iEWkLSZ14EBInLZ00RWxmC6EMZrzAeHNAWIgm+xP3NK0lqz+7lEsmWGtcl5gYnQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/encoding/-/encoding-1.0.1.tgz",
+      "integrity": "sha512-8opL2rs6N6E3tJfsqwS82aZQDL3gmupWUgmvuZ3CGU7z/InZs3R9jkzH8wmYtpbq0sFK3WkJkQRZFFk4BkrmFA==",
       "requires": {
         "is-typedarray": "1.0.0",
         "typedarray-to-buffer": "3.1.5"
@@ -24843,13 +24843,13 @@
       "integrity": "sha512-4BwqyWy6KpSvkocSaV7WR3BlZfrxLbJSLkg+j7Gl6pTDE+U55lLhJvQaMuDVazXYxcjBsG09k7UlH7cGiUI5vQ=="
     },
     "@walletconnect/iso-crypto": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@walletconnect/iso-crypto/-/iso-crypto-1.7.4.tgz",
-      "integrity": "sha512-oqLuBcORDO0doaK7LYissviUVlS//jdrhK8GnMMI6mkNh195FHURoi7jUvSE8Nxr5doUNRi9d7bDrEujA++xtw==",
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@walletconnect/iso-crypto/-/iso-crypto-1.7.8.tgz",
+      "integrity": "sha512-Qo6qDcMG0Ac+9fpWE0h/oE55NHLk6eM2vlXpWlQDN/me7RZGrkvk+LXsAkQ3UiYPEiPfq4eswcyRWC9AcrAscg==",
       "requires": {
-        "@walletconnect/crypto": "^1.0.1",
-        "@walletconnect/types": "^1.7.4",
-        "@walletconnect/utils": "^1.7.4"
+        "@walletconnect/crypto": "^1.0.2",
+        "@walletconnect/types": "^1.7.8",
+        "@walletconnect/utils": "^1.7.8"
       }
     },
     "@walletconnect/jsonrpc-types": {
@@ -24861,9 +24861,9 @@
       }
     },
     "@walletconnect/jsonrpc-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.0.tgz",
-      "integrity": "sha512-qUHbKUK6sHeHn67qtHZoLoYk5hS6x1arTPjKDRkY93/6Fx+ZmNIpdm1owX3l6aYueyegJ7mz43FpvYHUqJ8xcw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.1.tgz",
+      "integrity": "sha512-Ptmcq5SsXlJDE4xuwiqpCGZddPxvneXwDfQL20Ut4TyuZZwR4ZhNFcUBu3FDHBbtDL5qojnmZ1GHqABLJchpBQ==",
       "requires": {
         "@walletconnect/environment": "^1.0.0",
         "@walletconnect/jsonrpc-types": "^1.0.0"
@@ -24875,11 +24875,11 @@
       "integrity": "sha512-ZtKRio4uCZ1JUF7LIdecmZt7FOLnX72RPSY7aUVu7mj7CSfxDwUn6gBuK6WGtH+NZCldBqDl5DenI5fFSvkKYw=="
     },
     "@walletconnect/randombytes": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/randombytes/-/randombytes-1.0.1.tgz",
-      "integrity": "sha512-YJTyq69i0PtxVg7osEpKfvjTaWuAsR49QEcqGKZRKVQWMbGXBZ65fovemK/SRgtiFRv0V8PwsrlKSheqzfPNcg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/randombytes/-/randombytes-1.0.2.tgz",
+      "integrity": "sha512-ivgOtAyqQnN0rLQmOFPemsgYGysd/ooLfaDA/ACQ3cyqlca56t3rZc7pXfqJOIETx/wSyoF5XbwL+BqYodw27A==",
       "requires": {
-        "@walletconnect/encoding": "^1.0.0",
+        "@walletconnect/encoding": "^1.0.1",
         "@walletconnect/environment": "^1.0.0",
         "randombytes": "^2.1.0"
       }
@@ -24890,29 +24890,29 @@
       "integrity": "sha512-QJzp/S/86sUAgWY6eh5MKYmSfZaRpIlmCJdi5uG4DJlKkZrHEF7ye7gA+VtbVzvTtpM/gRwO2plQuiooIeXjfg=="
     },
     "@walletconnect/socket-transport": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@walletconnect/socket-transport/-/socket-transport-1.7.4.tgz",
-      "integrity": "sha512-5RDIZtyQqs5LFqmluE/5Gy4obaClGVDrhlhZJTUn86R49FppJq2pe362NnoJt6J6xLSLZlZ54WIBl6cIlRoVww==",
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@walletconnect/socket-transport/-/socket-transport-1.7.8.tgz",
+      "integrity": "sha512-bqEjLxfSzG79v2OT7XVOZoyUkg6g3yng0fURrdLusWs42fYHWnrSrIZDejFn8N5PiZk5R2edrggkQ7w0VUUAfw==",
       "requires": {
-        "@walletconnect/types": "^1.7.4",
-        "@walletconnect/utils": "^1.7.4",
+        "@walletconnect/types": "^1.7.8",
+        "@walletconnect/utils": "^1.7.8",
         "ws": "7.5.3"
       }
     },
     "@walletconnect/types": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-1.7.4.tgz",
-      "integrity": "sha512-jvdW1/7z16dCC3i2uwPSgXjUXkmvJH0M2PbYD8ZETyEj/oSiLd32nPAUZVU0IVqQk4XAZHUTKhlRgxTch1W4Qg=="
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-1.7.8.tgz",
+      "integrity": "sha512-0oSZhKIrtXRJVP1jQ0EDTRtotQY6kggGjDcmm/LLQBKnOZXdPeo0sPkV/7DjT5plT3O7Cjc6JvuXt9WOY0hlCA=="
     },
     "@walletconnect/utils": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-1.7.4.tgz",
-      "integrity": "sha512-09667lbpClPpbskCpLllAQ3MSiNnDlTlqcmWANJ/ZuqCqq5ENyytPqkUjPFSfRfRVkgdQ2t/byeQtDd1TEpHcg==",
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-1.7.8.tgz",
+      "integrity": "sha512-DSpfH6Do0TQmdrgzu+SyjVhupVjN0WEMvNWGK9K4VlSmLFpCWfme7qxzrvuxBZ47gDqs1kGWvjyJmviWqvOnAg==",
       "requires": {
-        "@walletconnect/browser-utils": "^1.7.4",
-        "@walletconnect/encoding": "^1.0.0",
+        "@walletconnect/browser-utils": "^1.7.8",
+        "@walletconnect/encoding": "^1.0.1",
         "@walletconnect/jsonrpc-utils": "^1.0.0",
-        "@walletconnect/types": "^1.7.4",
+        "@walletconnect/types": "^1.7.8",
         "bn.js": "4.11.8",
         "js-sha3": "0.8.0",
         "query-string": "6.13.5"
@@ -25201,22 +25201,22 @@
       "integrity": "sha512-F1tGh056XczEaEAqu7s+hlZUDWwOBT70Eq0lfMpBP2YguSQVyxRbprLq5rELXKQOyOaixTWYhMeMQMzP0U5FoQ=="
     },
     "algorand-walletconnect-qrcode-modal": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/algorand-walletconnect-qrcode-modal/-/algorand-walletconnect-qrcode-modal-1.7.4.tgz",
-      "integrity": "sha512-Xj/zt4O6o3f6H8ikXX5yrwVL+/VVwTpFF4N4daHaoK/HEooAGNdkrJ7vftbjhIrs0N8+b8NUqEcMyYdaCS/CKQ==",
+      "version": "1.7.8-beta.1",
+      "resolved": "https://registry.npmjs.org/algorand-walletconnect-qrcode-modal/-/algorand-walletconnect-qrcode-modal-1.7.8-beta.1.tgz",
+      "integrity": "sha512-ayQCMADLTrxe9XCvnuUhMq61KKL7OE1kKA4UO0dwO6qW55ZapQUtWILePSM2zy4Zxw7tZ9yVgsx4D3cXCYgjog==",
       "requires": {
-        "@walletconnect/browser-utils": "^1.7.4",
+        "@walletconnect/browser-utils": "^1.7.8",
         "@walletconnect/mobile-registry": "^1.4.0",
-        "@walletconnect/types": "^1.7.4",
+        "@walletconnect/types": "^1.7.8",
         "copy-to-clipboard": "^3.3.1",
         "preact": "10.4.1",
         "qrcode": "1.4.4"
       }
     },
     "algosdk": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/algosdk/-/algosdk-1.13.1.tgz",
-      "integrity": "sha512-htyJI1/zVcOzpNZVT8PHn4K0yXXTS+b7RXplc7nmFqGVThbM8+ufbnBLChxVPh3BVxqqpqS13VTsQcNArK10jg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/algosdk/-/algosdk-1.17.0.tgz",
+      "integrity": "sha512-WwHbZV03tZ2C/VLOapWOzJImm4lokav9HXnPLqbGrXyb8Gn/Q2AsoKMbOxd6MTzWguhaXU4Yk0VtbFlYhkaeoA==",
       "requires": {
         "algo-msgpack-with-bigint": "^2.1.1",
         "buffer": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
   },
   "dependencies": {
     "@json-rpc-tools/utils": "^1.7.6",
-    "@walletconnect/client": "^1.7.4",
-    "algorand-walletconnect-qrcode-modal": "^1.7.4",
-    "algosdk": "^1.13.1",
+    "@walletconnect/client": "^1.7.8",
+    "algorand-walletconnect-qrcode-modal": "^1.7.8-beta.1",
+    "algosdk": "^1.17.0",
     "blockies-ts": "^1.0.0",
     "prop-types": "^15.7.2",
     "qr-image": "^3.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ import Modal from "./components/Modal";
 import Header from "./components/Header";
 import Loader from "./components/Loader";
 import { fonts } from "./styles";
-import { apiGetAccountAssets, apiSubmitTransactions, ChainType } from "./helpers/api";
+import { getChainId, apiGetAccountAssets, apiSubmitTransactions, ChainType } from "./helpers/api";
 import { IAssetData, IWalletTransaction, SignTxnParams } from "./helpers/types";
 import AccountAssets from "./components/AccountAssets";
 import { Scenario, scenarios, signTxnWithTestAccount } from "./scenarios";
@@ -186,7 +186,7 @@ class App extends React.Component<unknown, IAppState> {
     // check if already connected
     if (!connector.connected) {
       // create new session
-      await connector.createSession();
+      await connector.createSession({ chainId: getChainId(this.state.chain) });
     }
 
     // subscribe to events
@@ -253,6 +253,15 @@ class App extends React.Component<unknown, IAppState> {
   };
 
   public chainUpdate = (newChain: ChainType) => {
+    const { connector } = this.state;
+
+    if (connector) {
+      connector.updateSession({
+        chainId: getChainId(newChain),
+        accounts: this.state.accounts,
+      });
+    }
+
     this.setState({ chain: newChain }, this.getAccountAssets);
   };
 

--- a/src/helpers/api.ts
+++ b/src/helpers/api.ts
@@ -6,6 +6,17 @@ export enum ChainType {
   TestNet = "testnet",
 }
 
+export function getChainId(chain: ChainType): number {
+  switch (chain) {
+    case ChainType.MainNet:
+      return 416001;
+    case ChainType.TestNet:
+      return 416002;
+    default:
+      throw new Error(`Unknown chain type: ${chain}`);
+  }
+}
+
 const mainNetClient = new algosdk.Algodv2("", "https://mainnet-api.algonode.cloud", "");
 const testNetClient = new algosdk.Algodv2("", "https://testnet-api.algonode.cloud", "");
 


### PR DESCRIPTION
Support for changes from the ARC-25 standard, tracked by https://github.com/algorandfoundation/ARCs/pull/96

Changes needed:
- [x] Support new chain IDs
- [x] Add Algorand marker to WC URIs -- waiting on https://github.com/algorand/walletconnect-monorepo/pull/2